### PR TITLE
Workaround for BTreeMap::new requiring const Ord

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -11,7 +11,7 @@ impl Extensions {
     #[inline]
     pub const fn new() -> Self {
         Self {
-            inner: BTreeMap::new(),
+            inner: crate::new_btreemap(),
         }
     }
 

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -24,7 +24,7 @@ impl HttpResponse {
             inner: Self {
                 version: Version::Http10,
                 status,
-                headers: BTreeMap::new(),
+                headers: crate::new_btreemap(),
                 body: Body::Empty,
             },
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub(crate) const fn new_btreemap<K: ?const Ord, V>() -> BTreeMap<K, V> {
     use std::mem::{forget, transmute};
     use std::cmp::Ordering;
     #[derive(PartialEq, Eq, PartialOrd)]
-    #[transparent]
+    #[repr(transparent)]
     struct ConstOrdWrapper<T>(T);
 
     impl<T: ?const Ord> const Ord for ConstOrdWrapper<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
     const_fn_trait_bound,
     const_generics,
     const_trait_impl,
+    const_trait_bound_opt_out,
     const_mut_refs,
     option_result_unwrap_unchecked
 )]
@@ -26,6 +27,8 @@ pub mod middleware;
 
 pub mod error;
 
+use std::collections::BTreeMap;
+
 pub use crate::{app::App, responder::Responder, server::HttpServer};
 
 #[doc(inline)]
@@ -42,6 +45,36 @@ pub mod web {
         },
         route::{connect, delete, get, head, options, patch, post, put, to, trace},
     };
+}
+
+// FIXME Remove this in the future
+pub(crate) const fn new_btreemap<K: ?const Ord, V>() -> BTreeMap<K, V> {
+    use std::mem::{forget, transmute};
+    use std::cmp::Ordering;
+    #[derive(PartialEq, Eq, PartialOrd)]
+    struct ConstOrdWrapper<T>(T);
+
+    impl<T: ?const Ord> const Ord for ConstOrdWrapper<T> {
+        fn cmp(&self, _: &Self) -> Ordering {
+            Ordering::Equal
+        }
+        fn max(self, s: Self) -> Self { 
+            forget(s);
+            self 
+        }
+        fn min(self, s: Self) -> Self { 
+            forget(s);
+            self 
+        }
+        fn clamp(self, a: Self, b: Self) -> Self { 
+            forget(a);
+            forget(b);
+            self 
+        } 
+    }
+    unsafe {
+        transmute::<BTreeMap<ConstOrdWrapper<K>, V>, _>(BTreeMap::new())
+    }
 }
 
 // A module for testing different route handlers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub(crate) const fn new_btreemap<K: ?const Ord, V>() -> BTreeMap<K, V> {
     use std::mem::{forget, transmute};
     use std::cmp::Ordering;
     #[derive(PartialEq, Eq, PartialOrd)]
+    #[transparent]
     struct ConstOrdWrapper<T>(T);
 
     impl<T: ?const Ord> const Ord for ConstOrdWrapper<T> {


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/87375, using `BTreeMap::new` is no longer possible due to it requiring a `const Ord` impl where it does not need to. I have included a workaround here for now, it will get fixed in the future.